### PR TITLE
fix(styles): adjust opacity and z-index for lqip image when JavaScript is disabled (#12)

### DIFF
--- a/src/styles/lqip.css
+++ b/src/styles/lqip.css
@@ -28,3 +28,10 @@
   position: relative;
   overflow: hidden;
 }
+
+@media (scripting: none) {
+  [data-astro-lqip] {
+    --opacity: 0;
+    --z-index: 1;
+  }
+}


### PR DESCRIPTION
This pull request fixes #12 and add a small update to the `src/styles/lqip.css` file, adding a media query to improve styling for environments where scripting is disabled.

### Accessibility and progressive enhancement:

* Added a `@media (scripting: none)` rule to set custom CSS variables (`--opacity` and `--z-index`) for elements with the `[data-astro-lqip]` attribute, ensuring better visualization when JavaScript is not available.

### Preview

https://github.com/user-attachments/assets/2acb4907-12ea-48ef-9e08-4eced86bc20a
